### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "mongoose": "^8.0.3",
     "node-cron": "^3.0.3",
     "rss-parser": "^3.13.0",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const mongoose = require('mongoose');
 const server = express();
 const cors = require('cors');
@@ -7,6 +8,12 @@ const episodeRoute = require('./routes/EpisodeRoute');
 const platformRoute = require('./routes/PlatformRoute');
 const errorMiddleware = require('./middleware/ErrorMiddleware');
 const path = require('path');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 server.use(express.json());
 server.use(cors());
@@ -43,7 +50,7 @@ const buildPath = path.join(__dirname, "../frontend/build");
 if(process.env.NODE_ENV === 'production'){
   server.use(express.static(buildPath));
 
-  server.get('*/', (req, res) => {
+  server.get('*/', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, '../frontend/build/index.html'))
   })
 } else {


### PR DESCRIPTION
Fixes [https://github.com/Engombe23/OccultPod-Web/security/code-scanning/1](https://github.com/Engombe23/OccultPod-Web/security/code-scanning/1)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will limit the number of requests that can be made to the server within a specified time window, thus mitigating the risk of a DoS attack.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/server.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the specific route that performs the file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
